### PR TITLE
Check for empty queue to prevent deadlock

### DIFF
--- a/bin/heap2raster.rb
+++ b/bin/heap2raster.rb
@@ -108,7 +108,7 @@ init()
 glutReshapeFunc(reshape)
 glutDisplayFunc(display)
 glutIdleFunc(lambda {
-  queue.pop
+  queue.pop unless queue.empty?
   glutPostRedisplay
 })
 glutMainLoop()


### PR DESCRIPTION
On subsequent runs the queue.pop will create a deadlock state. 
I am not sure if this is the correct fix, but checking if the queue is empty first prevents the deadlock
