### PR TITLE
Replace JSON with a more binary transport mechanism

### DIFF
--- a/bin/heap2raster.rb
+++ b/bin/heap2raster.rb
@@ -1,7 +1,6 @@
 require 'opengl'
 require 'glu'
 require 'glut'
-require 'json'
 require 'socket'
 
 include Gl,Glu,Glut
@@ -85,12 +84,19 @@ end
 
 queue = Queue.new
 
+def parse line
+  line.chomp.split("\t").each_slice(2).collect { |page, heap|
+    {"page" => page.to_i, "heap" => heap.bytes}
+  } << {}
+end
+
+Thread.abort_on_exception = true
 Thread.new do
   server = UNIXServer.new ARGV[0]
   sock = server.accept
   puts "CONNECTED"
   while z = sock.readline
-    heap = JSON.parse z
+    heap = parse z
     $bitmap = make_bitmap heap
     queue << :updated
   end

--- a/ext/heapfrag/heapfrag.c
+++ b/ext/heapfrag/heapfrag.c
@@ -14,7 +14,7 @@ int object_itr(void * start, void * finish, size_t step, void * data)
     size_t n;
     ID flags[5];
 
-    dprintf(info->fd, "{\"page\":%d,\"heap\":[", info->pages_seen);
+    dprintf(info->fd, "%d\t", info->pages_seen);
     for(; v != (VALUE)finish; v += step) {
 	switch (BUILTIN_TYPE(v)) {
 	    default: {
@@ -25,24 +25,21 @@ int object_itr(void * start, void * finish, size_t step, void * data)
 				 if(ID_old == flags[i]) is_old = 1;
 			     }
 			     if (is_old) {
-				 dprintf(info->fd, "2");
+				 dprintf(info->fd, "%c", 2);
 			     } else {
-				 dprintf(info->fd, "1");
+				 dprintf(info->fd, "%c", 1);
 			     }
 			 } else {
-			     dprintf(info->fd, "1");
+			     dprintf(info->fd, "%c", 1);
 			 }
 			 break;
 		     }
 	    case T_NONE:
-		dprintf(info->fd, "0");
+		dprintf(info->fd, "%c", 0);
 		break;
 	}
-	if ((v + step) != (VALUE)finish) {
-	    dprintf(info->fd, ",");
-	}
     }
-    dprintf(info->fd, "]},");
+    dprintf(info->fd, "\t");
     info->pages_seen++;
     return 0;
 }
@@ -60,9 +57,8 @@ static void realtime_handler(int signum, siginfo_t *info, void *context)
     ruby_info.pages_seen = 0;
     ruby_info.fd = write_fd;
 
-    dprintf(ruby_info.fd, "[");
     rb_objspace_each_objects(object_itr, &ruby_info);
-    dprintf(ruby_info.fd, "{}]\n");
+    dprintf(ruby_info.fd, "\n");
     in_signal--;
 }
 


### PR DESCRIPTION
Parse time of the payload dropped from 0.0026s to 0.0006s for the simple
payload in the examples.

Before JSON:

```
[{"page":1,"heap":[0,1,0,1]},{"page":2,"heap":[1,0,1,0]},{}]\n
```

After:

```
1\t\000\001\000\001\t2\t\001\000\001\000\n
```

---

@tenderlove I'm not sure how to measure the client side (in heapfrag.c).  The client side might be a little faster since it has less to create, but I expect the slow part is the loop itself.

You can ignore merging this if you want to keep the JSON.  I was just curious if eliminating the JSON would help.

I also noticed that the page number is never used ([see here](https://github.com/Fryguy/heapfrag/blob/a9bd1bd4a3fa3ae123f286e880efc88b1f04ac95/bin/heap2raster.rb#L14-L16)), so we might be able to just eliminate it altogether.
